### PR TITLE
`warp` service improvements

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -743,6 +743,7 @@
   ./services/networking/charybdis.nix
   ./services/networking/cjdns.nix
   ./services/networking/cloudflare-dyndns.nix
+  ./services/networking/cloudflare-warp.nix
   ./services/networking/cntlm.nix
   ./services/networking/connman.nix
   ./services/networking/consul.nix

--- a/nixos/modules/services/networking/cloudflare-warp.nix
+++ b/nixos/modules/services/networking/cloudflare-warp.nix
@@ -1,0 +1,54 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.cloudflare-warp;
+
+in {
+  meta.maintainers = with maintainers; [ wolfangaukang ];
+
+  options = {
+    services.cloudflare-warp = {
+      enable = mkEnableOption "cloudflare-warp, a service that replaces the connection between your device and the Internet with a modern, optimized, protocol";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = with pkgs; [ cloudflare-warp ];
+
+    users.users.warp = {
+      isSystemUser = true;
+      group = "warp";
+      description = "Cloudflare Warp user";
+      home = "/var/lib/cloudflare-warp";
+    };
+    users.groups.warp = {};
+
+    systemd = {
+      packages = [ pkgs.cloudflare-warp ];
+      services.warp-svc = {
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = {
+          StateDirectory = "cloudflare-warp";
+          User = "warp";
+          Umask = "0077";
+          # Hardening
+          LockPersonality = true;
+          PrivateMounts = true;
+          PrivateTmp = true;
+          ProtectControlGroups = true;
+          ProtectHostname = true;
+          ProtectKernelLogs = true;
+          ProtectKernelModules = true;
+          ProtectKernelTunables = true;
+          ProtectProc = "invisible";
+          # Leaving on strict activates warp on plus
+          ProtectSystem = "full";
+          RestrictNamespaces = true;
+          RestrictRealtime = true;
+        };
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -84,6 +84,7 @@ in {
   cjdns = handleTest ./cjdns.nix {};
   clickhouse = handleTest ./clickhouse.nix {};
   cloud-init = handleTest ./cloud-init.nix {};
+  cloudflare-warp = handleTest ./cloudflare-warp.nix {};
   cntr = handleTest ./cntr.nix {};
   cockroachdb = handleTestOn ["x86_64-linux"] ./cockroachdb.nix {};
   collectd = handleTest ./collectd.nix {};

--- a/nixos/tests/cloudflare-warp.nix
+++ b/nixos/tests/cloudflare-warp.nix
@@ -1,0 +1,30 @@
+import ./make-test-python.nix ({ pkgs, ... }: {
+  name = "cloudflare-warp";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ wolfangaukang ];
+  };
+
+  nodes.machine =
+    { lib, ... }:
+
+    {
+      # cloudflare-warp is unfree
+      nixpkgs.config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [
+        "cloudflare-warp"
+      ];
+      services.cloudflare-warp = {
+        enable = true;
+      };
+    };
+
+  # As the commands are automated, we will need to add the
+  # --accept-tos flag. Also, as there is no internet connection,
+  # We will only test the registration, which should work
+  testScript = ''
+    machine.wait_for_unit("warp-svc.service")
+    file = "/var/lib/cloudflare-warp/settings.json"
+    machine.wait_for_file(file);
+    machine.succeed("warp-cli --accept-tos register")
+    machine.wait_for_console_text("Success")
+  '';
+})

--- a/pkgs/tools/networking/cloudflare-warp/default.nix
+++ b/pkgs/tools/networking/cloudflare-warp/default.nix
@@ -1,23 +1,21 @@
-{ stdenv, lib, fetchurl, dpkg, autoPatchelfHook, dbus }:
+{ stdenv, lib, fetchurl, dpkg, autoPatchelfHook, makeWrapper, dbus, nftables }:
 
 stdenv.mkDerivation rec {
   pname = "cloudflare-warp";
-  version = "2022.02.24";
+  version = "2022.4.235";
 
   src = fetchurl {
-    url = "https://pkg.cloudflareclient.com/uploads/cloudflare_warp_2022_2_288_1_amd64_a0be7b47b3.deb";
-    sha256 = "sha256-gBXF0EfFMT6BC6ts/6PQYJH3AAQSDsFoZGK3RZIqmOA=";
+    url = "https://pkg.cloudflareclient.com/uploads/cloudflare_warp_2022_4_235_1_amd64_ef47e885f0.deb";
+    sha256 = "sha256-ngBPEmIaQs0cRjVv1ss3tk77N3G8BtTiEIaPj+CU9DY=";
   };
 
   nativeBuildInputs = [
     dpkg
     autoPatchelfHook
+    makeWrapper
   ];
 
   buildInputs = [ dbus ];
-
-  dontBuild = true;
-  dontConfigure = true;
 
   unpackPhase = ''
     dpkg-deb -x ${src} ./
@@ -27,15 +25,21 @@ stdenv.mkDerivation rec {
     runHook preInstall
 
     mv usr $out
-    mv lib $out
     mv bin $out
+    mv etc $out
+    mv lib/systemd/system $out/lib/systemd/
+
+    substituteInPlace $out/lib/systemd/system/warp-svc.service \
+      --replace "ExecStart=" "ExecStart=$out"
+
+    substituteInPlace $out/lib/systemd/user/warp-taskbar.service \
+      --replace "ExecStart=" "ExecStart=$out"
 
     runHook postInstall
   '';
 
   postInstall = ''
-    substituteInPlace $out/lib/systemd/system/warp-svc.service \
-      --replace "ExecStart=" "ExecStart=$out"
+    wrapProgram $out/bin/warp-svc --prefix PATH : ${lib.makeBinPath [ nftables ]}
   '';
 
   meta = with lib; {


### PR DESCRIPTION
## simplify customization & testing
Adds the following options

- package
- user
- group

## certificate
Simplifies certificate installation described [in the docs](https://developers.cloudflare.com/cloudflare-one/connections/connect-devices/warp/install-cloudflare-cert/#nix-and-nixos).

## udpPort & openFirewall
Simplifies firewall configuration using the same `openFirewall` nomenclature used w/ [many other services](https://search.nixos.org/options?query=openFirewall) including ssh.  This is useful for some users because warp binds to UDP port 2408.  However, users can also specify one of the fallback ports described [in the docs](https://developers.cloudflare.com/cloudflare-one/connections/connect-devices/warp/deployment/firewall#warp-udp-ports), 

## refined the systemd service unit
I used the approach described in [this forum post](https://discourse.nixos.org/t/using-cloudflared-with-zero-trust-dashboard-on-nixos/19069/8?u=daf).